### PR TITLE
Add option to suppress scheduled summaries without active alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project is a bridge between Grafana Alerting and Matrix. It receives webhoo
 - **Periodic Summaries:**
   - Sends a digest of active alerts at specific scheduled times defined in UTC.
   - Helps keep track of long-running issues.
+  - By default even summaries without active alerts are sent. This can be disabled to reduce messages.
 - **Persistence:** All internal state is stored in a SQLiteDB, allowing for restarts without a flood of messages during startup.
 
 ## Prerequisites
@@ -72,6 +73,7 @@ GRAFANA_API_KEY=your_grafana_api_key
 MENTION_CONFIG_PATH=./mention-config.json
 SUMMARY_SCHEDULE_CRIT=08:00,16:00  # UTC times
 SUMMARY_SCHEDULE_WARN=08:00        # UTC times
+SUMMARY_SCHEDULE_SKIP_EMPTY=false  # default (set to true to skip scheduled summaries without active alerts)
 
 # Storage
 DB_FILE=alerts.db

--- a/flake.nix
+++ b/flake.nix
@@ -205,6 +205,13 @@
               description = "UTC times for warning alert summaries (comma-separated)";
             };
 
+            summaryScheduleSkipEmpty = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              example = "true";
+              description = "Do not send empty scheduled alert summaries if true";
+            };
+
             dbFilename = mkOption {
               type = types.str;
               default = "alerts.db";
@@ -250,6 +257,8 @@
                       SUMMARY_SCHEDULE_CRIT = toString cfg.summaryScheduleCrit;
                     } // optionalAttrs (cfg.summaryScheduleWarn != null) {
                       SUMMARY_SCHEDULE_WARN = toString cfg.summaryScheduleWarn;
+                    } // optionalAttrs (cfg.summaryScheduleSkipEmpty != null) {
+                      SUMMARY_SCHEDULE_SKIP_EMPTY = cfg.summaryScheduleSkipEmpty;
                     }
                   )
                 );

--- a/src/config.js
+++ b/src/config.js
@@ -61,6 +61,7 @@ export function reloadConfig() {
     config.GRAFANA_API_KEY = get('GRAFANA_API_KEY');
     config.SUMMARY_SCHEDULE_CRIT = get('SUMMARY_SCHEDULE_CRIT');
     config.SUMMARY_SCHEDULE_WARN = get('SUMMARY_SCHEDULE_WARN');
+    config.SUMMARY_SCHEDULE_SKIP_EMPTY = get('SUMMARY_SCHEDULE_SKIP_EMPTY', false);
     config.MENTION_CONFIG_PATH = get('MENTION_CONFIG_PATH');
     config.DB_FILE = get('DB_FILE', 'alerts.db');
 }


### PR DESCRIPTION
Hi!

This PR adds the new option `SUMMARY_SCHEDULE_SKIP_EMPTY` which allows users to suppress scheduled summaries where there is no active alert. It defaults to `true`, so existing deployments will continue working without any changes required. 

Also, it is now possible to use boolean values with environment variables.