### PR TITLE
Fix npmDepsHash in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
 
           src = ./.;
 
-          npmDepsHash = "sha256-SZ5RSBBxaIgA5+cBvkWrsFpcEUvDQCqP1UwyMSkhygI=";
+          npmDepsHash = "sha256-fKs3hHa9q2uJqZ0eSb0Eul71WY6QCQy6sAbNP/eP7NA=";
 
           nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
 


### PR DESCRIPTION
Hi!

Just fixing the `npmDepsHash` in `flake.nix` after adjusting the `package-lock.json`. :)